### PR TITLE
Fixed broken path issue in shutil.move

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,7 +167,8 @@ except Exception as exc:
 
 Logger.info('Installing the KivyMD library ...')
 
-PATH_TO_APPLIBS = os.path.join(FULL_PATH_TO_PROJECT, 'libs', 'applibs')
+PATH_TO_FOLDER = os.path.dirname(os.path.abspath( __file__ ))
+PATH_TO_APPLIBS = os.path.join(PATH_TO_FOLDER, FULL_PATH_TO_PROJECT, 'libs', 'applibs')
 PATH_TO_KIVYMD = os.path.join(PATH_TO_APPLIBS, 'KivyMD')
 PATH_TO_KIVYMD_OLD = os.path.join(PATH_TO_APPLIBS, 'KivyMD_old')
 


### PR DESCRIPTION
shutil.move expects a full path, but FULL_PATH_TO_PROJECT wasn't really the full path. it was only starting at the project name
this caused a crash:

 Traceback (most recent call last):
   File "main.py", line 180, in <module>
     os.rename(PATH_TO_KIVYMD, PATH_TO_KIVYMD_OLD)
 OSError: [Errno 2] No such file or directory

PATH_TO_FOLDER is where the script resides, so shutil.move correctly moves the folder and no more error